### PR TITLE
Split handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,5 +66,7 @@ script:
   # Ensure remote_syslog.service is running.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl -l is-enabled remote_syslog'
 
-# notifications:
-#   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  # Rough test of /etc/log_files.yml content
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm grep "  host: fake_host"       /etc/log_files.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm grep "  port: 11111"           /etc/log_files.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm grep "  - /var/log/cron"       /etc/log_files.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ before_install:
 
 script:
   # Start the container from the image and perform tests.
-  
+
   # Create a random file to store the container ID.
   - container_id=$(mktemp)
 
   # Run container detached, with our role mounted inside.
-  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-role-papertrail:ro ${run_opts} chrisshort/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-role-papertrail:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
   # Check the role/playbook's syntax.
   - >
@@ -66,5 +66,5 @@ script:
   # Ensure remote_syslog.service is running.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl -l is-enabled remote_syslog'
 
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+# notifications:
+#   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ansible Role: Papertrail
 [![Build Status](https://travis-ci.org/chris-short/ansible-role-papertrail.svg?branch=master)](https://travis-ci.org/chris-short/ansible-role-papertrail)
 
 Split handlers branch:
-[![Build Status](https://travis-ci.org/flatrocks/ansible-role-papertrail.svg?branch=split_handlers)](https://travis-ci.org/chris-short/ansible-role-papertrail)
+[![Build Status](https://travis-ci.org/flatrocks/ansible-role-papertrail.svg?branch=split_handlers)](https://travis-ci.org/flatrocks/ansible-role-papertrail)
 
 
 Papertrail can utilize rsyslog and it's go utility remote_syslog2. This role configures and deploys all the neccessary bits to utilize Papertrail on EL7, Debian 8, and Ubuntu 16.04 systems

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Ansible Role: Papertrail
 
 [![Build Status](https://travis-ci.org/chris-short/ansible-role-papertrail.svg?branch=master)](https://travis-ci.org/chris-short/ansible-role-papertrail)
 
+Split handlers branch:
+[![Build Status](https://travis-ci.org/flatrocks/ansible-role-papertrail.svg?branch=split_handlers)](https://travis-ci.org/chris-short/ansible-role-papertrail)
+
+
 Papertrail can utilize rsyslog and it's go utility remote_syslog2. This role configures and deploys all the neccessary bits to utilize Papertrail on EL7, Debian 8, and Ubuntu 16.04 systems
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Ansible Role: Papertrail
 Split handlers branch:
 [![Build Status](https://travis-ci.org/flatrocks/ansible-role-papertrail.svg?branch=split_handlers)](https://travis-ci.org/flatrocks/ansible-role-papertrail)
 
-
 Papertrail can utilize rsyslog and it's go utility remote_syslog2. This role configures and deploys all the neccessary bits to utilize Papertrail on EL7, Debian 8, and Ubuntu 16.04 systems
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Ansible Role: Papertrail
 
 [![Build Status](https://travis-ci.org/chris-short/ansible-role-papertrail.svg?branch=master)](https://travis-ci.org/chris-short/ansible-role-papertrail)
 
-Split handlers branch:
-[![Build Status](https://travis-ci.org/flatrocks/ansible-role-papertrail.svg?branch=split_handlers)](https://travis-ci.org/flatrocks/ansible-role-papertrail)
-
 Papertrail can utilize rsyslog and it's go utility remote_syslog2. This role configures and deploys all the neccessary bits to utilize Papertrail on EL7, Debian 8, and Ubuntu 16.04 systems
 
 Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
 # defaults file for ansible-role-papertrail
-papertrail_version: "0.19"                                                                                                                        
-papertrail_files:                                                                                                                                 
-  - /var/log/cron
-  - /var/log/tuned/tuned.log                                                                                                                      
-  - /var/log/yum.log
-papertrail_host: []
-papertrail_port: []
+papertrail_version: "0.19"
+papertrail_files: []
+papertrail_host: ""
+papertrail_port: ""

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,5 +5,12 @@
 - name: daemon-reload
   shell: systemctl daemon-reload
 
-- name: enable remote syslog
-  service: name=remote_syslog.service enabled=yes state=started
+- name: enable remote_syslog
+  service:
+    name: remote_syslog.service
+    enabled: yes
+
+- name: restart remote_syslog
+  service:
+    name: remote_syslog.service
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,40 +1,40 @@
 ---
 - name: Install necessary packages
   package:
-    name={{ item }}
-    state=latest
+    name: "{{ item }}"
+    state: latest
   with_items:
     - rsyslog
     - rsyslog-gnutls
 
 - name: Obtain Papertrail Cert
   get_url:
-    dest=/etc/ssl/certs/papertrail-bundle.pem
-    url=https://papertrailapp.com/tools/papertrail-bundle.pem
+    dest: /etc/ssl/certs/papertrail-bundle.pem
+    url: https://papertrailapp.com/tools/papertrail-bundle.pem
   notify: restart rsyslog
 
 - name: Deploy rsyslog conf for Papertrail
   template:
-    src=papertrail.conf.j2
-    dest=/etc/rsyslog.d/papertrail.conf
-    owner=root
-    group=root
-    backup=no
+    src: papertrail.conf.j2
+    dest: /etc/rsyslog.d/papertrail.conf
+    owner: root
+    group: root
+    backup: no
   notify: restart rsyslog
 
 - name: Download remote_syslog
   get_url:
-    url="https://github.com/papertrail/remote_syslog2/releases/download/v{{ papertrail_version }}/remote_syslog_linux_amd64.tar.gz"
-    dest="/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
+    url: "https://github.com/papertrail/remote_syslog2/releases/download/v{{ papertrail_version }}/remote_syslog_linux_amd64.tar.gz"
+    dest: "/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
 
 - name: Extract remote_syslog
   unarchive:
-    src="/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
-    dest=/usr/local/src/
-    copy=no
-    owner=root
-    group=root
-    creates=/usr/local/src/remote_syslog/remote_syslog
+    src: "/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
+    dest: /usr/local/src/
+    copy: no
+    owner: root
+    group: root
+    creates: /usr/local/src/remote_syslog/remote_syslog
 
 - name: Copy remote_syslog to /usr/local/bin
   shell: cp /usr/local/src/remote_syslog/remote_syslog /usr/local/bin/remote_syslog
@@ -43,17 +43,18 @@
 
 - name: Deploy remote_syslog conf
   template:
-    src=log_files.yml.j2
-    dest=/etc/log_files.yml
-    owner=root
-    group=root
-    mode=0640
-  notify: enable remote syslog
+    src: log_files.yml.j2
+    dest: /etc/log_files.yml
+    owner: root
+    group: root
+    mode: 0640
+  notify: enable remote_syslog
 
 - name: Create remote_syslog systemd service
   template:
-    src=papertrail.service
-    dest=/etc/systemd/system/remote_syslog.service
+    src: papertrail.service
+    dest: /etc/systemd/system/remote_syslog.service
   notify:
     - daemon-reload
-    - enable remote syslog
+    - enable remote_syslog
+    - restart remote_syslog

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,1 @@
-[test]
 localhost

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,2 @@
+[test]
 localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,13 +2,11 @@
 
 - hosts: all
 
-  # vars:
-  #   papertrail_host: logs.papertrailapp.com
-  #   papertrail_port: 11111
-  #   papertrail_files:
-  #     - /var/log/cron
-  #     - /var/log/tuned/tuned.log
-  #     - /var/log/yum.log
+  vars:
+    papertrail_host: fake_host
+    papertrail_port: 11111
+    papertrail_files:
+      - /var/log/cron
 
   pre_tasks:
     - name: Ensure build dependencies are installed (Fedora).

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
+- hosts: test
 
   remote_user: root
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -35,4 +35,11 @@
       when: ansible_pkg_mgr =='apt'
 
   roles:
-    - ansible-role-papertrail
+    role: ansible-role-papertrail
+    # vars:
+    #   papertrail_host: logs.papertrailapp.com
+    #   papertrail_port: 11111
+    #   papertrail_files:
+    #     - /var/log/cron
+    #     - /var/log/tuned/tuned.log
+    #     - /var/log/yum.log

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,14 @@
 ---
-- hosts: test
 
-  remote_user: root
+- hosts: all
+
+  # vars:
+  #   papertrail_host: logs.papertrailapp.com
+  #   papertrail_port: 11111
+  #   papertrail_files:
+  #     - /var/log/cron
+  #     - /var/log/tuned/tuned.log
+  #     - /var/log/yum.log
 
   pre_tasks:
     - name: Ensure build dependencies are installed (Fedora).
@@ -35,11 +42,4 @@
       when: ansible_pkg_mgr =='apt'
 
   roles:
-    role: ansible-role-papertrail
-    # vars:
-    #   papertrail_host: logs.papertrailapp.com
-    #   papertrail_port: 11111
-    #   papertrail_files:
-    #     - /var/log/cron
-    #     - /var/log/tuned/tuned.log
-    #     - /var/log/yum.log
+    - ansible-role-papertrail


### PR DESCRIPTION
A bunch of small changes.  Detailed notes here for review.  Feel free to toss this back if this does not fit your ideas for the repo. 

**Splitting handlers**
* Previously, the remote_syslog handler include both `status` and `enabled` params.  Testing showed that this did not reliably do both.  Solution was to create two separate handlers.  Replaced the `started` state with `restarted` to force restart on a change to the service file.  _This change is what eventually solved all the functional problems._

**Testing** 
* deleted tests/inventory, not needed
* .travis.yml - a few changes to the test to get all passing, an added a simple test to verify template content

**General**
* defaults/main.yml - Set defaults to match expected type, removed some non-general default values. NOTE THIS WILL BREAK any Ansible config that relies on the previous default log file list (can be remedied by overriding the default empty set of log files.)
*  Reformatted the YAML a few places where string representations of hashes split across lines
